### PR TITLE
Improved compatibility with latest RxJs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuex-rx",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "RxJS middleware for vuex",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/src/ActionObservable.ts
+++ b/src/ActionObservable.ts
@@ -23,15 +23,17 @@ export class ActionsObservable<T> extends Observable<T> {
     return new this(from(ish, scheduler))
   }
 
-  constructor(actionsSubject: Observable<T>) {
-    super()
-    this.source = actionsSubject
+  constructor(actionsSubject?: Observable<T>) {
+    super();
+    if (actionsSubject != null)
+      this.source = actionsSubject;
   }
 
-  lift(operator: Function): Observable<T> {
-    const observable = new ActionsObservable(this)
-    observable.operator = operator
-    return observable
+  lift<R>(operator: Operator<T, R>): Observable<R> {
+    const observable = new ActionsObservable<R>();
+    observable.source = this;
+    observable.operator = operator;
+    return observable;
   }
 
   ofType(...keys: string[]) {


### PR DESCRIPTION
webpack throws an error:
```
ERROR in [at-loader] ./node_modules/vuex-rx/dist/ActionObservable.d.ts:4:22
    TS2415: Class 'ActionsObservable<T>' incorrectly extends base class 'Observable<T>'.
  Types of property 'lift' are incompatible.
    Type '(operator: Function) => Observable<T>' is not assignable to type '<R>(operator: Operator<T, R>) => Observable<R>'.
      Type 'Observable<T>' is not assignable to type 'Observable<R>'.
        Type 'T' is not assignable to type 'R'.
```
This is the fix for it.